### PR TITLE
Promise variable in init shouldn't be on Plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,29 +57,25 @@ var Cordova = function(id, emitter, args, logger, config) {
             errorHandler(write_err);
             return;
           }
-          var platforms = self.settings.platforms;
-          var plugins = self.settings.plugins;
-          var promise = runCordovaCmd(['plugin', 'add'].concat(plugins)).fail(errorHandler);
-      
-          for (var i=0; i<platforms.length; i++) {
-            promise = promise.then(
-              runCordovaCmd.bind({}, ['platform', 'add', platforms[i]]),
-              runCordovaCmd.bind({}, ['platform', 'add', platforms[i]])
-            );
+
+          var platforms = self.settings.platforms,
+              plugins = self.settings.plugins,
+              promise = runCordovaCmd.bind({}, ['platform', 'add'].concat(platforms));
+          
+          if (plugins && plugins.length) {
+            promise = promise.then(function() {
+              return runCordovaCmd(['plugin', 'add'].concat(plugins));
+            });
           }
-          promise = promise.then(function(result) {
-            console.log('Done adding platforms');
-          }, function(err) {
-            console.log('Done adding platforms');
-          });
       
-          promise = promise.then(runCordovaCmd.bind({}, ['build']), errorHandler);
+          promise = promise.then(runCordovaCmd.bind({}, ['build']));
           promise.then(function() {
             for (var i=0; i<platforms.length; i++) {
               runCordovaCmd(['emulate', platforms[i]], errorHandler); 
             }
-          }, errorHandler);
-
+          });
+          
+          promise.catch(errHandler);
         });
       });
     });


### PR DESCRIPTION
Currently, the Promise in the start function in the Cordova definition is created off the plugins settings and then chained off of by several other things. However, an app may not use plugins, in which case errors will occur. Platforms are required, which makes them a more suitable candidate to start the promise chain. I've prototyped that here, just to give an idea of how this might work, though it is likely not exactly right (I'm doing it in the browser, so I can't see if it's working).
