### PR TITLE
Ability to initialize the test iframe

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,11 +63,16 @@ var Cordova = function(id, emitter, args, logger, config) {
         }
         var newUrl = url + "?id=" + id;
         var ip = '10.0.2.2'; //default ip used by the Android emulator
+        var init = '';
         if(self.settings.hostip) {
           ip = self.settings.hostip;
         }
         newUrl = newUrl.replace(/localhost/g, ip);
         var toWrite = read_data.toString().replace(/NEWURL/g, newUrl);
+        if(self.settings.init) {
+          init = self.settings.init;
+        }
+        toWrite = toWrite.replace(/INIT/g, init);
         fs.writeFile(CORDOVA_DIR + "/www/js/inserttest.js", toWrite, function (write_err) {
           if (write_err) {
             errorHandler(write_err);

--- a/package.json
+++ b/package.json
@@ -6,18 +6,14 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/freedomjs/karma-cordova-launcher.git"
+    "url": "git@github.com:freedomjs/karma-cordova-launcher.git"
   },
   "keywords": [
     "karma-plugin",
     "karma-launcher",
     "cordova"
   ],
-  "author": {
-    "name": "Raymond Cheng",
-    "email": "ryscheng@cs.washington.edu",
-    "url": "http://raymondcheng.net"
-  },
+  "author": "Raymond Cheng <ryscheng@cs.washington.edu> (http://raymondcheng.net)",
   "dependencies": {
     "q": "~0.9.6",
     "ncp": "^0.5.1",
@@ -33,32 +29,5 @@
   "peerDependencies": {
     "karma": ">=0.12.16"
   },
-  "license": "Apache-2.0",
-  "gitHead": "7ee0b879f437d9b075a84183392cd66e86df8507",
-  "bugs": {
-    "url": "https://github.com/freedomjs/karma-cordova-launcher/issues"
-  },
-  "homepage": "https://github.com/freedomjs/karma-cordova-launcher#readme",
-  "_id": "karma-cordova-launcher@0.0.9",
-  "_shasum": "7df0632529447dfa5a782f13831a2f44304ec28a",
-  "_from": "karma-cordova-launcher@latest",
-  "_npmVersion": "3.3.8",
-  "_nodeVersion": "4.2.1",
-  "_npmUser": {
-    "name": "ryscheng",
-    "email": "ryscheng@cs.washington.edu"
-  },
-  "dist": {
-    "shasum": "7df0632529447dfa5a782f13831a2f44304ec28a",
-    "tarball": "https://registry.npmjs.org/karma-cordova-launcher/-/karma-cordova-launcher-0.0.9.tgz"
-  },
-  "maintainers": [
-    {
-      "name": "ryscheng",
-      "email": "ryscheng@cs.washington.edu"
-    }
-  ],
-  "directories": {},
-  "_resolved": "https://registry.npmjs.org/karma-cordova-launcher/-/karma-cordova-launcher-0.0.9.tgz",
-  "readme": "ERROR: No README data found!"
+  "license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -6,14 +6,18 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git@github.com:freedomjs/karma-cordova-launcher.git"
+    "url": "git+ssh://git@github.com/freedomjs/karma-cordova-launcher.git"
   },
   "keywords": [
     "karma-plugin",
     "karma-launcher",
     "cordova"
   ],
-  "author": "Raymond Cheng <ryscheng@cs.washington.edu> (http://raymondcheng.net)",
+  "author": {
+    "name": "Raymond Cheng",
+    "email": "ryscheng@cs.washington.edu",
+    "url": "http://raymondcheng.net"
+  },
   "dependencies": {
     "q": "~0.9.6",
     "ncp": "^0.5.1",
@@ -29,5 +33,32 @@
   "peerDependencies": {
     "karma": ">=0.12.16"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "gitHead": "7ee0b879f437d9b075a84183392cd66e86df8507",
+  "bugs": {
+    "url": "https://github.com/freedomjs/karma-cordova-launcher/issues"
+  },
+  "homepage": "https://github.com/freedomjs/karma-cordova-launcher#readme",
+  "_id": "karma-cordova-launcher@0.0.9",
+  "_shasum": "7df0632529447dfa5a782f13831a2f44304ec28a",
+  "_from": "karma-cordova-launcher@latest",
+  "_npmVersion": "3.3.8",
+  "_nodeVersion": "4.2.1",
+  "_npmUser": {
+    "name": "ryscheng",
+    "email": "ryscheng@cs.washington.edu"
+  },
+  "dist": {
+    "shasum": "7df0632529447dfa5a782f13831a2f44304ec28a",
+    "tarball": "https://registry.npmjs.org/karma-cordova-launcher/-/karma-cordova-launcher-0.0.9.tgz"
+  },
+  "maintainers": [
+    {
+      "name": "ryscheng",
+      "email": "ryscheng@cs.washington.edu"
+    }
+  ],
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/karma-cordova-launcher/-/karma-cordova-launcher-0.0.9.tgz",
+  "readme": "ERROR: No README data found!"
 }

--- a/template/www/js/inserttest.js
+++ b/template/www/js/inserttest.js
@@ -5,4 +5,5 @@ var runTests = function() {
   testFrame.id = "test-frame";
   testFrame.src = "NEWURL";
   document.getElementsByTagName('body')[0].appendChild(testFrame);
+  INIT
 };


### PR DESCRIPTION
While using karma-cordova-launcher I had issues accessing window.cordova and (for my project very important) window.sqlitePlugin (from the cordova-sqlite-storage plugin). There was no way to access window.parent.* for this, as there was a protocol difference between the two sources (http:// and file://). To overcome this, I added an init property to the settings, which will be inserted after the test frame is added to the document.
Can you merge this (or something better) in the main repository?