### PR TITLE
Fix: Cordova plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,11 +85,10 @@ var Cordova = function(id, emitter, args, logger, config) {
           }
           var promise;
 
-          if (typeof plugins !== 'undefined') {
-            promise = runCordovaCmd(['plugin', 'add'].concat(plugins)).fail(errorHandler);
-          } else {
-            promise = runCordovaCmd(['plugin', 'add', 'org.apache.cordova.console']).fail(errorHandler);
-          }
+          if (typeof plugins === 'undefined') {
+            plugins = ['cordova-plugin-console', 'cordova-plugin-whitelist'];
+          } 
+          promise = runCordovaCmd(['plugin', 'add'].concat(plugins)).fail(errorHandler);
 
           for (var i=0; i<platforms.length; i++) {
             promise = promise.then(


### PR DESCRIPTION
Use cordova-plugin-console instead of org.apache.cordova.console
Add cordova-plugin-whitelist to allow fetching tests on Android with new Cordova