### PR TITLE
Remove isCaptured, kill and toString methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,20 +114,6 @@ var Cordova = function(id, emitter, args, logger, config, baseBrowserDecorator) 
       });
     });
   };
-
-  this.isCaptured = function() {
-    return true;
-  }
-
-  this.kill = function(done) {
-    self.log.debug("Killing");
-    done();
-  };
-
-  this.toString = function() {
-    return self.name;
-  };
-
 };
 
 // PUBLISH DI MODULE


### PR DESCRIPTION
These are all implemented by baseBrowserDecorator and the semantics
have changed slightly for kill.