### PR TITLE
use the correct plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ module.exports = function(config) {
       hostip: '10.0.2.2',
       target: '0468de2a213eae29',
       plugins: [
-        'org.apache.cordova.console'
+        'cordova-plugin-console'
       ]
     },
     browsers: ['Cordova'],


### PR DESCRIPTION
When using the configuration in the README, I received this error:
```
[spawn] stderr: Error: Registry returned 404 for GET on https://registry.npmjs.org/org.apache.cordova.console
```
Changing it this way allows the tests to get further. See also #8 